### PR TITLE
Handling nil response from Defensio

### DIFF
--- a/lib/defender/spammable.rb
+++ b/lib/defender/spammable.rb
@@ -182,13 +182,16 @@ module Defender
           'type' => (Defender.test_mode ? 'test' : 'comment')
         })
         data.merge!(defensio_data) if defined?(@_defensio_data)
-        document = Defender.defensio.post_document(data).last
-        if document['status'] == 'failed'
-          raise DefenderError, document['message']
+        if document = Defender.defensio.post_document(data).last
+          if document['status'] == 'failed'
+            raise DefenderError, document['message']
+          end
+          self.spam = !document['allow']
+          self.defensio_sig = document['signature'].to_s
+          self.spaminess = document['spaminess'] if self.respond_to?(:spaminess=)
+        else
+          raise DefenderError, 'Got nil response from Defensio API'
         end
-        self.spam = !document['allow']
-        self.defensio_sig = document['signature'].to_s
-        self.spaminess = document['spaminess'] if self.respond_to?(:spaminess=)
         true
       end
 

--- a/lib/defender/spammable.rb
+++ b/lib/defender/spammable.rb
@@ -190,7 +190,7 @@ module Defender
           self.defensio_sig = document['signature'].to_s
           self.spaminess = document['spaminess'] if self.respond_to?(:spaminess=)
         else
-          raise DefenderError, 'Got nil response from Defensio API'
+          raise DefenderError, 'Got nil response from Defensio API, service might be down'
         end
         true
       end

--- a/spec/defender/spammable_spec.rb
+++ b/spec/defender/spammable_spec.rb
@@ -178,27 +178,38 @@ module Defender
         comment.save
         Defender.defensio = old_defensio
       end
+
+      it 'handles nil response from Defensio' do
+        old_defensio = Defender.defensio
+        defensio = double('defensio')
+        defensio.should_receive(:post_document) { [nil] }
+        Defender.defensio = defensio
+        comment = Comment.new
+        comment.body = 'Hello, world!'
+        lambda { comment.save }.should raise_error Defender::DefenderError
+        Defender.defensio = old_defensio
+      end
     end
-    
+
     describe '#_pick_attribute' do
       it 'returns the value of the attribute passed if it exists' do
         comment = Comment.new
         comment.body = 'Foobar!'
         comment.send(:_pick_attribute, :body).should == 'Foobar!'
       end
-      
+
       it 'returns the value for the first attribute that exists in a list of attributes' do
         comment = Comment.new
         comment.body = 'Foobar!'
         comment.send(:_pick_attribute, [:content, :body]).should == 'Foobar!'
       end
-      
+
       it 'returns nil if no attribute with the given names exists' do
         comment = Comment.new
-        comment.send(:_pick_attribute, :bogus_attribute).should be_nil 
+        comment.send(:_pick_attribute, :bogus_attribute).should be_nil
       end
     end
-    
+
     describe '#_get_defensio_document' do
       it 'retrieves the document from Defensio' do
         old_defensio = Defender.defensio


### PR DESCRIPTION
Hi,

I recently noticed that I was getting a few `NoMethodError: undefined method `[]' for nil:NilClass` in the error logs for project that uses the defender gem. The error originated from the `if document['status'] == 'failed'`line in `#_defender_before_create`. 

My guess is that the nil response has to do with httparty (defensio gem uses httparty for http requests) using Net::HTTP's `#request`call that doesn't raise any Net::\* exceptions when an error occurs. I guess the Defensio API was down or something like that..

I think it would be good if defender returned a more understandable error in this case, so I made it so a `DefenderError` is raised if the response is nil.

Let me know what you think! =)
